### PR TITLE
Type inference failed. Expected type mismatch: inferred type is Array…

### DIFF
--- a/android/src/main/kotlin/rocks/biessek/fluttercountrypicker/FlutterCountryPickerPlugin.kt
+++ b/android/src/main/kotlin/rocks/biessek/fluttercountrypicker/FlutterCountryPickerPlugin.kt
@@ -29,9 +29,9 @@ class FlutterCountryPickerPlugin(): MethodCallHandler {
     }
   }
 
-  private fun getAllCountryNames(isoCodes: ArrayList<String>): HashMap<String, String> {
+  private fun getAllCountryNames(isoCodes: ArrayList<String>?): HashMap<String, String> {
     val localCountries = HashMap<String, String>()
-    for (isoCode in isoCodes) {
+    for (isoCode:String in isoCodes!!.filterNotNull()) {
       localCountries[isoCode] = Locale("", isoCode).displayCountry
     }
     return localCountries


### PR DESCRIPTION
…List<String>? but ArrayList<String> was expected

Fixed issue that appeared with the new update on Kotlin/Flutter on Linux.

/development/flutter/.pub-cache/hosted/pub.dartlang.org/flutter_country_picker-0.1.0/android/src/main/kotlin/rocks/biessek/fluttercountrypicker/FlutterCountryPickerPlugin.kt: (26, 46): Type inference failed. Expected type mismatch: inferred type is ArrayList<String>? but ArrayList<String> was expected

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':flutter_country_picker:compileDebugKotlin'.
> Compilation error. See log for more details